### PR TITLE
tests workflow and measurements type hint fixes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,21 +1,18 @@
 name: Tests
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
   pull_request:
     branches: [main]
     paths-ignore:
       - 'docs/**'
       - '*.md'
+  workflow_dispatch:
 
 jobs:
   test-cpp:
     name: C++ Tests
     runs-on: trueform-linux
+    environment: tests
 
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +28,7 @@ jobs:
   test-python:
     name: Python Tests
     runs-on: trueform-linux
+    environment: tests
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/content/py/2.modules/4.geometry.md
+++ b/docs/content/py/2.modules/4.geometry.md
@@ -127,9 +127,11 @@ sv_flipped = tf.signed_volume((faces[:, ::-1], points))  # -24.0
 
 | **Function** | **Input** | **Description** |
 |--------------|-----------|-----------------|
-| `area` | `ndarray`, `Polygon`, `Mesh`, or tuple | Area of polygon or total surface area |
-| `volume` | `Mesh` or tuple (3D only) | Absolute volume of closed mesh |
-| `signed_volume` | `Mesh` or tuple (3D only) | Signed volume (orientation-dependent) |
+| `area` | `ndarray`, `Polygon`, `Mesh`, or `(faces, points)` tuple | Area of polygon or total surface area |
+| `volume` | `Mesh` or `(faces, points)` tuple (3D only) | Absolute volume of closed mesh |
+| `signed_volume` | `Mesh` or `(faces, points)` tuple (3D only) | Signed volume (orientation-dependent) |
+
+Tuple inputs accept both `ndarray` and `OffsetBlockedArray` for faces.
 
 ::note{icon="i-lucide-info"}
 Volume functions require 3D meshes. Signed volume is positive when face normals point outward (CCW winding).

--- a/python/src/trueform/_geometry/measurements.py
+++ b/python/src/trueform/_geometry/measurements.py
@@ -17,7 +17,7 @@ from .._dispatch import ensure_mesh, extract_meta, build_suffix
 
 
 def signed_volume(
-    data: Union[Mesh, Tuple[np.ndarray, np.ndarray]]
+    data: Union[Mesh, Tuple[np.ndarray, np.ndarray], Tuple[OffsetBlockedArray, np.ndarray]]
 ) -> float:
     """
     Compute signed volume of a closed 3D mesh.
@@ -31,6 +31,7 @@ def signed_volume(
     data : Mesh or tuple
         - Mesh: tf.Mesh object (must be 3D)
         - (faces, points): Tuple with face indices and point coordinates
+        - (OffsetBlockedArray, points): Dynamic polygon mesh
 
     Returns
     -------
@@ -54,7 +55,7 @@ def signed_volume(
 
 
 def volume(
-    data: Union[Mesh, Tuple[np.ndarray, np.ndarray]]
+    data: Union[Mesh, Tuple[np.ndarray, np.ndarray], Tuple[OffsetBlockedArray, np.ndarray]]
 ) -> float:
     """
     Compute volume of a closed 3D mesh.
@@ -66,6 +67,7 @@ def volume(
     data : Mesh or tuple
         - Mesh: tf.Mesh object (must be 3D)
         - (faces, points): Tuple with face indices and point coordinates
+        - (OffsetBlockedArray, points): Dynamic polygon mesh
 
     Returns
     -------

--- a/python/tests/test_triangulated.py
+++ b/python/tests/test_triangulated.py
@@ -293,6 +293,31 @@ def test_dynamic_2d(dtype):
     assert points.shape == (4, 2), f"Expected (4, 2), got {points.shape}"
 
 
+@pytest.mark.parametrize("dtype", REAL_DTYPES)
+@pytest.mark.parametrize("index_dtype", INDEX_DTYPES)
+def test_dynamic_mesh_object(dtype, index_dtype):
+    """Triangulate Mesh object created from OffsetBlockedArray."""
+    offsets = np.array([0, 4, 8], dtype=index_dtype)
+    data = np.array([0, 1, 2, 3, 1, 4, 5, 2], dtype=index_dtype)
+    dyn_faces = tf.OffsetBlockedArray(offsets, data)
+
+    points_in = np.array([
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0],
+        [0, 1, 0],
+        [2, 0, 0],
+        [2, 1, 0]
+    ], dtype=dtype)
+
+    mesh = tf.Mesh(dyn_faces, points_in)
+    faces, points = tf.triangulated(mesh)
+
+    # 2 quads -> 4 triangles
+    assert faces.shape == (4, 3), f"Expected (4, 3), got {faces.shape}"
+    assert points.shape == (6, 3), f"Expected (6, 3), got {points.shape}"
+
+
 # ==============================================================================
 # Correctness Tests
 # ==============================================================================


### PR DESCRIPTION
Workflow:
- Add environment approval for tests (requires manual approval)
- Remove push-to-main trigger (redundant with strict PR requirements)
- Add workflow_dispatch for manual runs

Python:
- Fix type hints for signed_volume/volume to include OffsetBlockedArray
- Add tests for dynamic mesh (tuple and Mesh object forms)
- Update geometry docs to clarify OffsetBlockedArray support